### PR TITLE
Ignore changes on secret name

### DIFF
--- a/deploy.tf
+++ b/deploy.tf
@@ -80,6 +80,12 @@ resource "kubernetes_service_account" "cicd" {
     name      = "cicd"
     namespace = "convictionsai"
   }
+
+  lifecycle {
+    ignore_changes = [
+        secret
+    ]
+  }
 }
 
 resource "kubernetes_cluster_role" "cicd" {


### PR DESCRIPTION
Ignore changes on the secret name, otherwise a service account created by the api repo gets overwrited by the app repo CI/CD run:
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with
the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # kubernetes_service_account.cicd will be updated in-place
  ~ resource "kubernetes_service_account" "cicd" {
        id                              = "convictionsai/cicd"
        # (2 unchanged attributes hidden)

      - secret {
          - name = "cicd-token-tdbvm" -> null
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

```