### PR TITLE
Fix(header): search input not alligned

### DIFF
--- a/deploy.tf
+++ b/deploy.tf
@@ -80,6 +80,12 @@ resource "kubernetes_service_account" "cicd" {
     name      = "cicd"
     namespace = "convictionsai"
   }
+
+  lifecycle {
+    ignore_changes = [
+        secret
+    ]
+  }
 }
 
 resource "kubernetes_cluster_role" "cicd" {

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -73,7 +73,7 @@ import { IconComponent } from "../icons/icon.component";
                                 (keyup.enter)="search()"
                                 type="search"
                                 id="search-dropdown"
-                                class="border-l-1 md:border-l-6 z-20 block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-primary-500 focus:ring-primary-500 dark:border-gray-600 dark:border-l-gray-600 dark:bg-gray-800 dark:text-white  dark:placeholder-gray-400 dark:focus:border-primary-500 md:rounded-l-none md:border-l-gray-50"
+                                class=" border-none border-l-1 md:border-l-6 z-20 block w-full rounded-lg border-gray-300 bg-gray-50 h-full text-sm text-gray-900 focus:border-primary-500 focus:ring-primary-500 dark:border-gray-600 dark:border-l-gray-600 dark:bg-gray-800 dark:text-white  dark:placeholder-gray-400 dark:focus:border-primary-500 rounded-l-none md:border-l-gray-50"
                                 placeholder="Search anything..."
                                 required />
                             <button


### PR DESCRIPTION
Fix unaligned search input on safari.
From:
<img width="687" alt="Screenshot 2023-03-29 at 01 41 59" src="https://user-images.githubusercontent.com/13653687/228342973-fda954dd-51d2-46c8-b8e6-78a95d04d416.png">

To:
<img width="671" alt="Screenshot 2023-03-29 at 02 07 04" src="https://user-images.githubusercontent.com/13653687/228343013-3689dd7b-1d20-40aa-a6dd-870efdbd4f04.png">
